### PR TITLE
Bring up to date with original repo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'be.appmire.flutterkeychain'
+
     compileSdkVersion 31
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'be.appmire.flutterkeychain'
+    if (project.android.hasProperty("namespace")) {
+        namespace 'be.appmire.flutterkeychain'
+    }
 
     compileSdkVersion 31
 


### PR DESCRIPTION
This pull request includes several changes to the `android/build.gradle` file to improve compatibility and configuration for the Android build system. The most important changes include adding a namespace property, updating compile options, and configuring Kotlin options.

Configuration improvements:

* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aR28-R42): Added a conditional check for the `namespace` property and set it to `'be.appmire.flutterkeychain'` if present.
* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aR28-R42): Added `compileOptions` to set `sourceCompatibility` and `targetCompatibility` to `JavaVersion.VERSION_1_8`.
* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aR28-R42): Added `kotlinOptions` to set `jvmTarget` to `'1.8'`.