### PR TITLE
chore: Remove registrar to allow Flutter upgrade

### DIFF
--- a/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
+++ b/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.math.BigInteger
 import java.nio.charset.Charset
 import java.security.*
@@ -286,25 +285,6 @@ class FlutterKeychainPlugin : FlutterPlugin, MethodCallHandler {
 
         lateinit private var encryptor: StringEncryptor
         lateinit private var preferences: SharedPreferences
-
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-
-            try {
-                preferences = registrar.context()
-                    .getSharedPreferences("FlutterKeychain", Context.MODE_PRIVATE)
-                encryptor = AesStringEncryptor(
-                    preferences = preferences,
-                    keyWrapper = RsaKeyStoreKeyWrapper(registrar.context())
-                )
-
-                val instance = FlutterKeychainPlugin()
-                instance.channel = MethodChannel(registrar.messenger(), channelName)
-                instance.channel?.setMethodCallHandler(FlutterKeychainPlugin())
-            } catch (e: Exception) {
-                Log.e("flutter_keychain", "Could not register plugin", e)
-            }
-        }
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {


### PR DESCRIPTION
Similar to this PR on the base repo, to allow for Flutter upgrade:

https://github.com/jeroentrappers/flutter_keychain/pull/53/files